### PR TITLE
add basic dbGetInfo (without user, host and port information yet)

### DIFF
--- a/R/clickhouse.R
+++ b/R/clickhouse.R
@@ -18,6 +18,22 @@ setClass("clickhouse_result",
   )
 )
 
+setMethod("dbGetInfo", "clickhouse_connection", def=function(dbObj, ...) {
+  envdata <- dbGetQuery(dbObj, "SELECT version() as version, uptime() as uptime, 
+                        currentDatabase() as database")
+  
+  ll$name <- "clickhouse_connection"
+  ll$db.version <- envdata$version
+  ll$uptime <- envdata$uptime
+  ll$url <- dbObj@url
+  ll$dbname <- envdata$database
+  ll$username <- NA
+  ll$host <- NA
+  ll$port <- NA
+  
+  ll
+})
+
 setMethod("dbIsValid", "clickhouse_driver", function(dbObj, ...) {
   TRUE
 })


### PR DESCRIPTION
I added a basic dbGetInfo-Method for the dbi interface. Username, host and port information are missing at the moment. I would use parse_url, but then we would have an additional dependency... maybe someone can provide a nice regex instead.