### PR TITLE
Added Date datatype to dbDataType method

### DIFF
--- a/R/clickhouse.R
+++ b/R/clickhouse.R
@@ -221,6 +221,7 @@ setMethod("dbDataType", signature(dbObj="clickhouse_connection", obj = "ANY"), d
   if (is.logical(obj)) "UInt8"
   else if (is.integer(obj)) "Int32"
   else if (is.numeric(obj)) "Float64"
+  else if (class(obj) == "Date") "Date"
   else "String"
 }, valueClass = "character")
 


### PR DESCRIPTION
Needed to use engine = MergeTree(...), otherwise Date types are passed through as strings and table creation fails.